### PR TITLE
Updating Docksal configuration and instructions

### DIFF
--- a/.docksal/commands/init
+++ b/.docksal/commands/init
@@ -37,9 +37,11 @@ site_install ()
     chmod -R a+w "${DOCROOT_PATH}/sites/default"
 
     echo-green "Install site from '${PROFILE_NAME}' profile."
+    # We disable email sending here so site-install does not return an error
     fin drush si -y ${PROFILE_NAME} \
+        install_configure_form.enable_update_status_module=NULL \
         --account-pass=admin \
-        --db-url="mysql://${MYSQL_USER:-user}:${MYSQL_PASSWORD:-user}@db:${MYSQL_PORT_MAPPING:-3306}/${MYSQL_DATABASE:-default}" \
+        --db-url="mysql://${MYSQL_USER:-user}:${MYSQL_PASSWORD:-user}@db:3306/${MYSQL_DATABASE:-default}" \
         --root="${SERVER_DOCROOT_PATH}"
 
     echo-green "Clear caches."
@@ -65,12 +67,6 @@ progress_bar
 
 echo-green-bg " Step 3: Installing site. "
 time site_install
-
-if is_windows; then
-	echo-green "Add ${VIRTUAL_HOST} to your hosts file (/etc/hosts), e.g.:"
-	echo-green "192.168.64.100  ${VIRTUAL_HOST}"
-	echo
-fi
 
 echo -en "${green_bg} DONE! ${NC} "
 echo "Open http://${VIRTUAL_HOST} in your browser to verify the setup."

--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -2,5 +2,29 @@
 # To override a variable locally:
 # - create .docksal/docksal-local.env file and local variable overrides there
 # - add .docksal/docksal-local.env to .gitignore
+#
+# After editing, apply changes with 'fin up'
 
-CLI_IMAGE="docksal/cli:edge-php7.1"
+# Use the default Docksal LAMP stack
+DOCKSAL_STACK=default
+
+# Lock images versions for LAMP services
+# This will prevent images from being updated when Docksal is updated
+#WEB_IMAGE='docksal/web:x.x-apache2.4'
+#DB_IMAGE='docksal/db:x.x-mysql-5.6'
+#CLI_IMAGE='docksal/cli:x.x-php7.1'
+
+# Override virtual host (matches project folder name by default)
+#VIRTUAL_HOST=drupal8.docksal
+# Override document root ('docroot' by default)
+#DOCROOT=docroot
+
+# MySQL settings.
+# MySQL will be exposed on a random port. Use "fin ps" to check the port.
+# To have a static MySQL port assigned, copy the line below into the .docksal/docksal-local.env file
+# and replace the host port "0" with a unique host port number (e.g. MYSQL_PORT_MAPPING='33061:3306')
+MYSQL_PORT_MAPPING='0:3306'
+
+# Enable/disable xdebug
+# To override locally, copy the two lines below into .docksal/docksal-local.env and adjust as necessary
+XDEBUG_ENABLED=0

--- a/.docksal/docksal.yml
+++ b/.docksal/docksal.yml
@@ -7,60 +7,8 @@
 # - add .docksal/docksal-local.yml to .gitignore
 
 # Docksal stiches several docker-compose configuration files together.
-# Run "fin config" to see which files are involved and the resulting configration.
+# Run "fin config" to see which files are involved and the resulting configuration.
 
 version: "2.1"
 
-services:
-  # Web
-  web:
-    hostname: web
-    image: ${WEB_IMAGE:-docksal/web:latest}
-    volumes:
-      - project_root:/var/www:ro,nocopy  # Project root volume
-    labels:
-      - io.docksal.virtual-host=${VIRTUAL_HOST},*.${VIRTUAL_HOST}
-      - io.docksal.project-root=${PROJECT_ROOT}
-    environment:
-      - APACHE_DOCUMENTROOT=/var/www/${DOCROOT:-docroot}
-      - APACHE_BASIC_AUTH_USER
-      - APACHE_BASIC_AUTH_PASS
-    dns:
-      - ${DOCKSAL_DNS1}
-      - ${DOCKSAL_DNS2}
-
-  # DB
-  db:
-    hostname: db
-    image: ${DB_IMAGE:-docksal/db:latest}
-    ports:
-      - "${MYSQL_PORT_MAPPING:-3306}"
-    volumes:
-      - project_root:/var/www:ro,nocopy  # Project root volume
-    environment:
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-root}
-      - MYSQL_USER=${MYSQL_USER:-user}
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-user}
-      - MYSQL_DATABASE=${MYSQL_DATABASE:-default}
-    dns:
-      - ${DOCKSAL_DNS1}
-      - ${DOCKSAL_DNS2}
-
-  # CLI - Used for all console commands and tools.
-  cli:
-    hostname: cli
-    image: ${CLI_IMAGE:-docksal/cli:latest}
-    volumes:
-      - project_root:/var/www:rw,nocopy  # Project root volume
-      - docksal_ssh_agent:/.ssh-agent:ro  # Shared ssh-agent socket
-      - /home/docker  # Write-heavy directories should be in volumes. See https://github.com/docksal/docksal/issues/325
-      - ${PROJECT_ROOT}/.docksal/etc/php/php.ini:/usr/local/etc/php/conf.d/z_php.ini:ro
-    environment:
-      - HOST_UID
-      - HOST_GID
-      - DOCROOT
-      - XDEBUG_ENABLED=${XDEBUG_ENABLED:-0}
-      - XDEBUG_CONFIG=remote_connect_back=0 remote_host=${DOCKSAL_HOST_IP}  # Point xdebug to the host IP
-    dns:
-      - ${DOCKSAL_DNS1}
-      - ${DOCKSAL_DNS2}
+# Note: Using default Docksal stack. Only put overrides and extra services here.

--- a/.docksal/etc/php/php-fpm.conf
+++ b/.docksal/etc/php/php-fpm.conf
@@ -1,0 +1,4 @@
+; PHP FPM settings
+[www]
+; Maximum amount of memory a script may consume
+php_admin_value[memory_limit] = -1

--- a/.docksal/etc/php/php.ini
+++ b/.docksal/etc/php/php.ini
@@ -1,3 +1,4 @@
+; Global PHP settings
 [php]
 memory_limit = -1
 max_input_time = -1
@@ -13,15 +14,5 @@ error_reporting = E_ALL | E_STRICT
 html_errors = On
 log_errors = On
 
-; https://php.net/manual/en/ini.core.php#ini.always-populate-raw-post-data
-always_populate_raw_post_data = -1
-
 [Date]
 date.timezone = America/New_York
-
-[xdebug]
-xdebug.remote_enable = 1
-xdebug.remote_connect_back = 1
-xdebug.remote_port = 9000
-xdebug.max_nesting_level = 256
-zend_extension = "/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so"

--- a/README.md
+++ b/README.md
@@ -8,25 +8,19 @@ You need to install Docksal on your local machine according to [Docksal setup](h
 
 ### Full install from scratch
 
-You should have php-cli (7.1) installed on your computer
+Note: a local instance of PHP and/or Composer is not required.
 
-```sh
-php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php composer-setup.php
-sudo mv composer.phar /usr/local/bin/composer
+```bash
+# Install Docksal
+curl -fsSL https://get.docksal.io | bash
 # Change directory to your workspace
-composer create-project ymcatwincities/openy-project openy --no-interaction --no-dev
-cd openy/
-composer install
-# Install Doksal
-curl -fsSL https://get.docksal.io | sh
-fin init
-fin vm restart
+fin run-cli composer create-project ymcatwincities/openy-project openy --no-interaction --no-dev
+cd openy
+fin run-cli composer install
 fin init
 ```
 
 You should see something like
-
 
 ```
 MBP-Andrii:openy podarok$ fin init
@@ -139,19 +133,26 @@ You can now include content into the sitemap by visiting the corresponding entit
 for additional entity types and custom links can be added on the module's configuration pages.
 The XML sitemap has been regenerated for all languages.                                                                                [status]
 Congratulations, you installed OpenY!    
+Clear caches.
+Cache rebuild complete.                                                                                                                [ok]
+Created three GoogleTagManager snippet files based on configuration.                                                                   [status]
+
+real    22m8.914s
+user    0m1.720s
+sys     0m0.780s
+ DONE!  Open http://openy.docksal in your browser to verify the setup.
 ```
 
-By visiting http://openy.docksal/ you'll see your local copy of the latest stable OpenY. If you have root folder different than `/openy`, by default the virtual host name is equal to the project's folder name without spaces and dashes, with the .docksal domain appended to it.
-```
-openy-project => openyproject.docksal
-```
+Open the URL printed at the end of the setup (e.g. `http://openy.docksal`) to see your local copy of the latest stable OpenY.
 
 # Docksal environment for OpenY
 
 Open the project's folder and run 
+
 ```
 fin init
 ```
+
 to start the project.
 
 The webserver starts up, and the site will be installed automatically.
@@ -163,9 +164,10 @@ Administrator account is _admin_:_admin_.
 After you run the "fin init" and have your environment ready you need to do few things.
 
 - Create a fork of [http://github.com/ymcatwincities/openy](http://github.com/ymcatwincities/openy).
-- In your project go to `docroot/profiles/contrib/openy` and edit **.git/config file**. Replace repo URL to your newly created fork.
-- Then you can create a branch in your repo, push some code and create a pull request back to ymcatwincities/openy repo.
+- In your project go to `docroot/profiles/contrib/openy` and edit `.git/config` file. Replace repo URL to your newly created fork.
+- Then you can create a branch in your repo, push some code and create a pull request back to `ymcatwincities/openy` repo.
 
 # How to run behat tests?
 
-Then edit behat.local.yml and change base_url to "web" and wd_host to "http://browser:4444/wd/hub". Then you can run your behat tests with "./vendor/behat/behat/bin/behat".
+Edit `behat.local.yml` and set `base_url` to `web` and `wd_host` to `http://browser:4444/wd/hub`. 
+Then you can run your behat tests with `./vendor/behat/behat/bin/behat`.


### PR DESCRIPTION
Here's the summary of changes

- Use default Docksal stack
  - Standard LAMP stack definition that ships by default with Docksal (same as in the https://github.com/docksal/drupal8 example setup).
  - This ensures compatibility between Docksal versions and Docksal stack configuration in the project.
- Updated PHP settings overrides
  - Starting with docksal/cli v2 PHP settings are split into php.ini (global) and php-fpm.ini (web)
  - Removed always_populate_raw_post_data - already set in docksal/cli
  - Disabled xdebug and removed xdebug settings. This speeds up site setup 3.5x times(!!!). See https://docs.docksal.io/en/master/tools/xdebug/ on how to properly switch xdebug on/off in Docksal.
- Updated `init` command
  - Disabled email sending on site-install. Without this the script fails right after the drush site-install command (which exists with 1).
  - Updated the db-url string
  - Removed the message for Windows users - no longer applicable in recent Docksal versions.
- Updated docs
  - Local PHP and Composer and not required with Docksal
  - Use "fin run-cli" for php/composer commands to create a project
  - Update the notice about the project URL