### PR TITLE
[OPENY-275] Add build_project command

### DIFF
--- a/.docksal/commands/build_project
+++ b/.docksal/commands/build_project
@@ -72,16 +72,15 @@ cleanup ()
 init_git_repo ()
 {
   cd "$OPENY_PATH"
-  git init
-  git add --all >/dev/null
-  git commit -m "Initial commit" >/dev/null
-  git remote rm origin
-  git remote add origin "$GIT_REMOTE_ORIGIN"
-  if [ ! -z "$GIT_REMOTE_UPSTREAM" ]; then
-    git remote add upstream "$GIT_REMOTE_UPSTREAM"
+  fin exec "rm -rf .git"
+  fin exec "git init"
+  fin exec "git add --all" >/dev/null
+  fin exec 'git commit -m "Initial commit"' >/dev/null
+  fin exec "git remote add origin $GIT_REMOTE_ORIGIN"
+  if [ -n "$GIT_REMOTE_UPSTREAM" ]; then
+    fin exec "git remote add upstream $GIT_REMOTE_UPSTREAM"
   fi
-  git fetch openy >/dev/null
-  git checkout -b "openy/$OPENY_VERSION"
+  fin exec "git checkout -b origin/$OPENY_VERSION"
 }
 
 #-------------------------- END: Functions ---------------------------

--- a/.docksal/commands/build_project
+++ b/.docksal/commands/build_project
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+## Build Open Y project.
+##
+## See https://github.com/ymcatwincities/openy-project
+## Note: This command will remove all files in project, use with caution!
+##
+## Usage: fin build_project
+
+# Abort if anything fails
+set -e
+
+CURRENT_DIR="$(dirname "$0")"
+source "${CURRENT_DIR}/includes/helpers.sh"
+
+#-------------------------- Settings --------------------------------
+
+PROJECT_NAME="openy_project"
+COMPOSER_PROJECT="${PROJECT_ROOT}/${PROJECT_NAME}"
+DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT:-docroot}"
+OPENY_PATH="${DOCROOT_PATH}/profiles/contrib/openy"
+
+#-------------------------- END: Settings --------------------------------
+
+#-------------------------- Functions --------------------------------
+
+# Setup composer project.
+setup_project ()
+{
+  cd "$PROJECT_ROOT"
+  fin composer create-project "ymcatwincities/openy-project:$OPENY_PROJECT_VERSION" "$PROJECT_NAME" --no-interaction --no-dev
+  cd "$COMPOSER_PROJECT" && fin composer update
+
+  # Remove downloaded docksal directory.
+  rm -rf "${COMPOSER_PROJECT}/.docksal"
+  # Move all files from COMPOSER_PROJECT to root directory.
+  cd "$COMPOSER_PROJECT"
+  mv * .[^.]* ..
+  # Remove empty directory.
+  rm -rf "$COMPOSER_PROJECT"
+}
+
+# Cleanup project.
+cleanup ()
+{
+  cd "$PROJECT_ROOT"
+  # Remove all files and directories except listed.
+  ls -a | grep -v -e ".docksal" -e ".idea" -e "^.$" -e "^..$" | xargs rm -rf
+}
+
+# Init GIT repository in project.
+init_git_repo ()
+{
+  cd "$OPENY_PATH"
+  git init
+  git add --all >/dev/null
+  git commit -m "Initial commit" >/dev/null
+  git remote add openy "$GIT_REMOTE_OPENY"
+  if [ ! -z "$GIT_REMOTE_ORIGIN" ]; then
+    git remote add origin "$GIT_REMOTE_ORIGIN"
+  fi
+  git fetch openy >/dev/null
+  git checkout -b "openy/$OPENY_VERSION"
+}
+
+#-------------------------- END: Functions ---------------------------
+
+#-------------------------- Execution --------------------------------
+if [[ ${DOCKER_RUNNING} == "true" ]]; then
+  echo-green-bg " Step 1: Recreating services. "
+  fin reset -f
+else
+  echo-green-bg " Step 1: Creating services. "
+  fin up
+fi
+
+echo-green-bg " Step 2: Cleanup."
+time cleanup
+
+echo-green-bg " Step 3: Build project."
+time setup_project
+
+echo-green-bg " Step 4: Init git repo and add remote."
+time init_git_repo
+
+echo -en "${green_bg} DONE! ${NC} "
+echo "Run 'fin init' to install Open Y."
+
+#-------------------------- END: Execution ----------------------------------

--- a/.docksal/commands/build_project
+++ b/.docksal/commands/build_project
@@ -61,8 +61,8 @@ cleanup ()
   # Here we will get something like this:
   # ls -a | grep -v -e ".docksal" -e ".idea" -e "^.$" -e "^..$" | xargs rm -rf
   RM_CMD="$CMD | xargs rm -rf"
-  if [ -d "$DOCROOT_PATH" ]; then
-    fin exec "chmod 777 -R $DOCROOT_PATH"
+  if [[ -d "$DOCROOT_PATH" ]]; then
+    fin exec "chmod 777 -R $DOCROOT"
   fi
   # Execute command.
   fin exec "$RM_CMD"
@@ -80,7 +80,8 @@ init_git_repo ()
   if [ -n "$GIT_REMOTE_UPSTREAM" ]; then
     fin exec "git remote add upstream $GIT_REMOTE_UPSTREAM"
   fi
-  fin exec "git checkout -b origin/$OPENY_VERSION"
+  fin exec "git fetch origin"
+  fin exec "git checkout $OPENY_VERSION"
 }
 
 #-------------------------- END: Functions ---------------------------

--- a/.docksal/commands/build_project
+++ b/.docksal/commands/build_project
@@ -61,8 +61,11 @@ cleanup ()
   # Here we will get something like this:
   # ls -a | grep -v -e ".docksal" -e ".idea" -e "^.$" -e "^..$" | xargs rm -rf
   RM_CMD="$CMD | xargs rm -rf"
+  if [ -d "$DOCROOT_PATH" ]; then
+    fin exec "chmod 777 -R $DOCROOT_PATH"
+  fi
   # Execute command.
-  eval $CMD
+  fin exec "$RM_CMD"
 }
 
 # Init GIT repository in project.

--- a/.docksal/commands/build_project
+++ b/.docksal/commands/build_project
@@ -16,6 +16,7 @@ source "${CURRENT_DIR}/includes/helpers.sh"
 #-------------------------- Settings --------------------------------
 
 PROJECT_NAME="openy_project"
+IGNORE_REQUIRED="^.$ ^..$ .docksal"
 COMPOSER_PROJECT="${PROJECT_ROOT}/${PROJECT_NAME}"
 DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT:-docroot}"
 OPENY_PATH="${DOCROOT_PATH}/profiles/contrib/openy"
@@ -44,8 +45,24 @@ setup_project ()
 cleanup ()
 {
   cd "$PROJECT_ROOT"
-  # Remove all files and directories except listed.
-  ls -a | grep -v -e ".docksal" -e ".idea" -e "^.$" -e "^..$" | xargs rm -rf
+
+  # Build command based on settings.
+  IGNORE="$IGNORE_REQUIRED $IGNORE_CUSTOM"
+  CMD='ls -a | grep -v'
+  arr=(`echo ${IGNORE}`);
+
+  echo "Ignore ${#arr[*]} directories during cleanup:"
+  for ix in ${!arr[*]}
+  do
+    CMD="$CMD -e '${arr[$ix]}'"
+    printf "   %s\n" "- ${arr[$ix]}"
+  done
+
+  # Here we will get something like this:
+  # ls -a | grep -v -e ".docksal" -e ".idea" -e "^.$" -e "^..$" | xargs rm -rf
+  RM_CMD="$CMD | xargs rm -rf"
+  # Execute command.
+  eval $CMD
 }
 
 # Init GIT repository in project.

--- a/.docksal/commands/build_project
+++ b/.docksal/commands/build_project
@@ -57,6 +57,7 @@ init_git_repo ()
   git commit -m "Initial commit" >/dev/null
   git remote add openy "$GIT_REMOTE_OPENY"
   if [ ! -z "$GIT_REMOTE_ORIGIN" ]; then
+    git remote rm origin
     git remote add origin "$GIT_REMOTE_ORIGIN"
   fi
   git fetch openy >/dev/null

--- a/.docksal/commands/build_project
+++ b/.docksal/commands/build_project
@@ -55,10 +55,10 @@ init_git_repo ()
   git init
   git add --all >/dev/null
   git commit -m "Initial commit" >/dev/null
-  git remote add openy "$GIT_REMOTE_OPENY"
-  if [ ! -z "$GIT_REMOTE_ORIGIN" ]; then
-    git remote rm origin
-    git remote add origin "$GIT_REMOTE_ORIGIN"
+  git remote rm origin
+  git remote add origin "$GIT_REMOTE_ORIGIN"
+  if [ ! -z "$GIT_REMOTE_UPSTREAM" ]; then
+    git remote add upstream "$GIT_REMOTE_UPSTREAM"
   fi
   git fetch openy >/dev/null
   git checkout -b "openy/$OPENY_VERSION"

--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -34,7 +34,7 @@ XDEBUG_ENABLED=0
 # Latest DEVELOPMENT version (1.x) - 8.1.x-development-dev
 # Latest DEVELOPMENT version (2.x) - 8.2.x-development-dev
 # To override locally, copy the line below into .docksal/docksal-local.env and adjust as necessary
-OPENY_PROJECT_VERSION='8.2.x-dev'
+OPENY_PROJECT_VERSION='8.2.x-development-dev'
 
 # Open Y version.
 # See https://github.com/ymcatwincities/openy/

--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -44,8 +44,8 @@ OPENY_PROJECT_VERSION='8.2.x-development-dev'
 OPENY_VERSION='8.x-2.x'
 
 # Git remote used in build_project for initialized local repo.
-GIT_REMOTE_OPENY='git@github.com:ymcatwincities/openy.git'
+GIT_REMOTE_ORIGIN='git@github.com:ymcatwincities/openy.git'
 # If you have FORK of ymcatwincities/openy, add it to GIT_REMOTE_ORIGIN
-# Example: GIT_REMOTE_ORIGIN='git@github.com:ymcagtc/openy.git'
+# Example: GIT_REMOTE_UPSTREAM='git@github.com:ymcagtc/openy.git'
 # To override locally, copy the line below into .docksal/docksal-local.env and adjust as necessary
-GIT_REMOTE_ORIGIN=''
+GIT_REMOTE_UPSTREAM=''

--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -49,3 +49,8 @@ GIT_REMOTE_ORIGIN='git@github.com:ymcatwincities/openy.git'
 # Example: GIT_REMOTE_UPSTREAM='git@github.com:ymcagtc/openy.git'
 # To override locally, copy the line below into .docksal/docksal-local.env and adjust as necessary
 GIT_REMOTE_UPSTREAM=''
+
+# Directories names that should be ignored during cleanup.
+# The names list is separated by spaces
+# To override locally, copy the line below into .docksal/docksal-local.env and adjust as necessary
+IGNORE_CUSTOM=".idea"

--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -28,3 +28,24 @@ MYSQL_PORT_MAPPING='0:3306'
 # Enable/disable xdebug
 # To override locally, copy the two lines below into .docksal/docksal-local.env and adjust as necessary
 XDEBUG_ENABLED=0
+
+# Open Y project version.
+# See https://github.com/ymcatwincities/openy-project/
+# Latest DEVELOPMENT version (1.x) - 8.1.x-development-dev
+# Latest DEVELOPMENT version (2.x) - 8.2.x-development-dev
+# To override locally, copy the line below into .docksal/docksal-local.env and adjust as necessary
+OPENY_PROJECT_VERSION='8.2.x-dev'
+
+# Open Y version.
+# See https://github.com/ymcatwincities/openy/
+# Latest DEVELOPMENT version (1.x) - 8.x-1.x
+# Latest DEVELOPMENT version (2.x) - 8.x-2.x
+# To override locally, copy the line below into .docksal/docksal-local.env and adjust as necessary
+OPENY_VERSION='8.x-2.x'
+
+# Git remote used in build_project for initialized local repo.
+GIT_REMOTE_OPENY='git@github.com:ymcatwincities/openy.git'
+# If you have FORK of ymcatwincities/openy, add it to GIT_REMOTE_ORIGIN
+# Example: GIT_REMOTE_ORIGIN='git@github.com:ymcagtc/openy.git'
+# To override locally, copy the line below into .docksal/docksal-local.env and adjust as necessary
+GIT_REMOTE_ORIGIN=''

--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -53,4 +53,4 @@ GIT_REMOTE_UPSTREAM=''
 # Directories names that should be ignored during cleanup.
 # The names list is separated by spaces
 # To override locally, copy the line below into .docksal/docksal-local.env and adjust as necessary
-IGNORE_CUSTOM=".idea"
+IGNORE_CUSTOM='.idea'

--- a/README.md
+++ b/README.md
@@ -2,13 +2,60 @@ This is a Docksal-based for the [Open Y](https://github.com/ymcatwincities/openy
 
 [Docksal](https://docksal.io/) is used as a local development environment.
 
-## Get Started
+# Get Started
 
 You need to install Docksal on your local machine according to [Docksal setup](http://docksal.readthedocs.io/en/master/getting-started/env-setup/) instructions.
 
-### Full install from scratch
+## Full install from scratch
 
 Note: a local instance of PHP and/or Composer is not required.
+
+Follow these steps to get fully prepared project.
+
+#### Install Docksal
+```bash
+curl -fsSL https://get.docksal.io | bash
+```
+
+#### Clone OpenY dokcsal project
+```bash
+git clone git@github.com:ymcatwincities/openy-docksal.git
+```
+
+#### Add your custom settings
+
+- Create `docksal-local.env` file inside `.docksal` directory with content:
+```yaml
+OPENY_PROJECT_VERSION='8.2.x-dev'
+OPENY_VERSION='8.x-2.x'
+GIT_REMOTE_UPSTREAM='git@github.com:USER/openy.git'
+IGNORE_CUSTOM='.idea'
+```
+- Replace `USER` by your user name from github or remove `GIT_REMOTE_UPSTREAM` if you doesn't have fork of `ymcatwincities/openy`
+Also you can set here corresponding versions of openy-project and openy.
+
+- During execution of `build_project` command all directories except ignored will be deleted. 
+If you work on already existing project and want to save any folder in project root directory - add folder name
+to `IGNORE_CUSTOM`. Directories names should be separated by spaces.
+
+#### Build Open Y project
+Run this command inside your project directory:
+```bash
+fin build_project
+```
+As result you will get full Open Y installation in your file system.
+
+#### Install Open Y site
+
+After `fin build_project` command finish you need to install site. For this 
+you can use one of this commands:
+- `fin init`
+- `fin install_steps`
+- `fin upgrade_init`
+
+More details about this commands you can get below.
+
+## Alternative installation process
 
 ```bash
 # Install Docksal
@@ -20,49 +67,6 @@ fin run-cli composer install
 fin init
 ```
 
-You should see something like
-
-```
-MBP-Andrii:openy podarok$ fin init
- Step 1: Recreating services. 
-Removing containers...
-Removing network openy_default
-WARNING: Network openy_default not found.
-Removing volume openy_project_root
-WARNING: Volume openy_project_root not found.
-Volume docksal_ssh_agent is external, skipping
-Starting services...
-Creating network "openy_default" with the default driver
-Creating volume "openy_project_root" with local driver
-Pulling web (docksal/web:latest)...
-latest: Pulling from docksal/web
-88286f41530e: Pull complete
-Digest: sha256:8575b2bb305faa7cafaf209c259ad708431bf66a7f4ce3c08411854da211ac06
-Status: Downloaded newer image for docksal/cli:edge-php7.1
-Creating openy_cli_1 ... done
-Creating openy_db_1  ... done
-Creating openy_web_1 ... done
-Waiting for openy_cli_1 to become ready...
-Connected vhost-proxy to "openy_default" network.
- Step 2: Waiting 5s for MySQL to start. 
-[==========]
- Step 3: Installing site. 
-Install site from 'openy' profile.
-You are about to create a /var/www/docroot/sites/default/settings.php file and DROP all tables in your 'default' database. Do you want to continue? (y/n): y
-Starting Drupal installation. This takes a while. Consider using the --notify global option.                                           [ok]
-error sending mail
-2018/07/03 11:07:23 dial tcp 194.60.69.106:1025: getsockopt: connection timed out
-Installation complete.                                                                                                                 [ok]                                                                             [status]
-Congratulations, you installed Open Y!    
-Clear caches.
-Cache rebuild complete.                                                                                                                [ok]
-Created three GoogleTagManager snippet files based on configuration.                                                                   [status]
-
-real    22m8.914s
-user    0m1.720s
-sys     0m0.780s
- DONE!  Open http://openy.docksal in your browser to verify the setup.
-```
 
 Open the URL printed at the end of the setup (e.g. `http://openy.docksal`) to see your local copy of the latest stable Open Y.
 
@@ -71,31 +75,6 @@ Open the URL printed at the end of the setup (e.g. `http://openy.docksal`) to se
 Open the project's folder and run one of the commands.
 
 Administrator account is _admin_:_admin_.
-
-### How to build Open Y project ?
-With `build_project` command you can build Open Y project inside
-docker container, no need install composer on local environment for this.
-
-Follow these steps to get fully prepared project:
-
-- Clone openy-docksal:
-```bash
-git clone git@github.com:ymcatwincities/openy-docksal.git
-```
-- Create `docksal-local.env` file inside `.docksal` directory with content:
-```yaml
-OPENY_PROJECT_VERSION='8.2.x-dev'
-OPENY_VERSION='8.x-2.x'
-GIT_REMOTE_ORIGIN='git@github.com:USER/openy.git'
-```
-- Replace `USER` by your user name from github or remove `GIT_REMOTE_ORIGIN` if you doesn't have fork of `ymcatwincities/openy`
-Also you can set here corresponding versions of openy-project and openy.
-
-- Run `fin build_project` command inside your project directory.
-As result you will get full Open Y installation in your file system.
-
-- Last step - run `fin init` command inside your project directory.
-As result you will get installed site.
 
 ### Start the project
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Follow these steps to get fully prepared project.
 curl -fsSL https://get.docksal.io | bash
 ```
 
-#### Clone OpenY dokcsal project
+#### Clone OpenY docksal project
 ```bash
 git clone git@github.com:ymcatwincities/openy-docksal.git
 ```

--- a/README.md
+++ b/README.md
@@ -38,12 +38,26 @@ Also you can set here corresponding versions of openy-project and openy.
 If you work on already existing project and want to save any folder in project root directory - add folder name
 to `IGNORE_CUSTOM`. Directories names should be separated by spaces.
 
+If you want to use your fork as an origin remote and the main repository as an 
+upstream remote, add the following variables to the `docksal-local.env` file 
+as follows:
+```yaml
+GIT_REMOTE_UPSTREAM='git@github.com:ymcatwincities/openy.git'
+GIT_REMOTE_ORIGIN='git@github.com:USER/openy.git'
+```
+In this case, after project install git will already track the repositories 
+you specified as `origin` and `upstream` remotes
+
 #### Build Open Y project
 Run this command inside your project directory:
 ```bash
 fin build_project
 ```
 As result you will get full Open Y installation in your file system.
+
+The "Killed" message during command run usually means that you need to increase memory limits in your Docksal.
+For macOS or Windows overall memory volume available for Docker is limited by the virtual machine or Docker Desktop 
+settings.
 
 #### Install Open Y site
 

--- a/README.md
+++ b/README.md
@@ -37,71 +37,6 @@ Creating volume "openy_project_root" with local driver
 Pulling web (docksal/web:latest)...
 latest: Pulling from docksal/web
 88286f41530e: Pull complete
-744e41c53ade: Pull complete
-a81940df563c: Pull complete
-ffce8fc48231: Pull complete
-a8b049cfa846: Pull complete
-fea7b994aec2: Pull complete
-56467af11998: Pull complete
-29d43475459c: Pull complete
-b2680c5bb942: Pull complete
-Digest: sha256:152faca86dad3736a5631333e999b8133d83cdb9d0aa411b46f95d12dd91d8bd
-Status: Downloaded newer image for docksal/web:latest
-Pulling db (docksal/db:latest)...
-latest: Pulling from docksal/db
-2a72cbf407d6: Pull complete
-38680a9b47a8: Pull complete
-4c732aa0eb1b: Pull complete
-c5317a34eddd: Pull complete
-f92be680366c: Pull complete
-6762c4c3eacc: Pull complete
-7f9e7799488e: Pull complete
-5bfede7d51ce: Pull complete
-4d58e230ee6f: Pull complete
-e83cf84d215b: Pull complete
-9a02cf99f495: Pull complete
-6693741ec461: Pull complete
-431ca06706e2: Pull complete
-Digest: sha256:bb770c9e9d5d2897fe89473ab33d59e1fcb1717ae7be74a03119c014de368ac6
-Status: Downloaded newer image for docksal/db:latest
-Pulling cli (docksal/cli:edge-php7.1)...
-edge-php7.1: Pulling from docksal/cli
-f2aa67a397c4: Pulling fs layer
-c533bdb78a46: Pulling fs layer
-65a7293804ac: Pull complete
-35a9c1f94aea: Pull complete
-b6c541bc05dd: Pull complete
-3a0ebd442fec: Pull complete
-f6dc9c95b4d5: Pull complete
-dd9cb9ca3529: Pull complete
-5c7312d96c23: Pull complete
-bd640ed5b036: Pull complete
-ddbe6398edce: Pull complete
-61077a0984a0: Pull complete
-74951dc393a1: Pull complete
-b7c72847ff47: Pull complete
-c8c0e7a634ba: Pull complete
-e2c8095a1a06: Pull complete
-f04fd204a9c2: Pull complete
-d9e07fddc42a: Pull complete
-b62a0e1b7c9d: Pull complete
-2f472dd03641: Pull complete
-2657f4060957: Pull complete
-35686158b3b3: Pull complete
-1beb0fb2671f: Pull complete
-6f38547f805f: Pull complete
-ef3ac0591dd8: Pull complete
-9bbf20269efe: Pull complete
-6b7796e94a94: Pull complete
-6c4581a142c4: Pull complete
-3b5db81a74b2: Pull complete
-e5a17dc73c2c: Pull complete
-96e4e421816b: Pull complete
-c1d22a2f38f2: Pull complete
-b3866b41bcf8: Pull complete
-467bde025869: Pull complete
-14b97bdedf14: Pull complete
-4ad3db22d991: Pull complete
 Digest: sha256:8575b2bb305faa7cafaf209c259ad708431bf66a7f4ce3c08411854da211ac06
 Status: Downloaded newer image for docksal/cli:edge-php7.1
 Creating openy_cli_1 ... done
@@ -117,21 +52,7 @@ You are about to create a /var/www/docroot/sites/default/settings.php file and D
 Starting Drupal installation. This takes a while. Consider using the --notify global option.                                           [ok]
 error sending mail
 2018/07/03 11:07:23 dial tcp 194.60.69.106:1025: getsockopt: connection timed out
-Installation complete.                                                                                                                 [ok]
-Unable to send email. Contact the site administrator if the problem persists.                                                          [error]
-If you have not yet enabled any @font-your-face provider modules, please do so. If you have already enabled @font-your-face provider   [status]
-modules, please use the font settings page in the appearance section to import fonts from them.
-Created three GoogleTagManager snippet files based on configuration.                                                                   [status]
-You may now install your own custom fonts. Remember to follow the EULA for any given font.                                             [status]
-Optimizely database table has been created.                                                                                            [status]
-A default project / experiment entry has been created.                                                                                 [status]
-         Next, enter your Optimizely account ID on the module's ACCOUNT INFO page.
-         There is also an Optimizely permission that can be set for specific roles
-         to access the adminstration functionality.
-         You can access those pages via the Optimizely module below.
-You can now include content into the sitemap by visiting the corresponding entity type edit pages (e.g. node type edit pages).Support  [status]
-for additional entity types and custom links can be added on the module's configuration pages.
-The XML sitemap has been regenerated for all languages.                                                                                [status]
+Installation complete.                                                                                                                 [ok]                                                                             [status]
 Congratulations, you installed Open Y!    
 Clear caches.
 Cache rebuild complete.                                                                                                                [ok]
@@ -150,6 +71,31 @@ Open the URL printed at the end of the setup (e.g. `http://openy.docksal`) to se
 Open the project's folder and run one of the commands.
 
 Administrator account is _admin_:_admin_.
+
+### How to build Open Y project ?
+With `build_project` command you can build Open Y project inside
+docker container, no need install composer on local environment for this.
+
+Follow these steps to get fully prepared project:
+
+- Clone openy-docksal:
+```bash
+git clone git@github.com:ymcatwincities/openy-docksal.git
+```
+- Create `docksal-local.env` file inside `.docksal` directory with content:
+```yaml
+OPENY_PROJECT_VERSION='8.2.x-dev'
+OPENY_VERSION='8.x-2.x'
+GIT_REMOTE_ORIGIN='git@github.com:USER/openy.git'
+```
+- Replace `USER` by your user name from github or remove `GIT_REMOTE_ORIGIN` if you doesn't have fork of `ymcatwincities/openy`
+Also you can set here corresponding versions of openy-project and openy.
+
+- Run `fin build_project` command inside your project directory.
+As result you will get full Open Y installation in your file system.
+
+- Last step - run `fin init` command inside your project directory.
+As result you will get installed site.
 
 ### Start the project
 


### PR DESCRIPTION
Add new command for build Open Y project inside docksal.

**Steps for review:**

- [ ]  Clone openy-docksal and add this changes
- [ ]  Create `docksal-local.env` file inside `.docksal` directory with content:
```yaml
OPENY_PROJECT_VERSION='8.2.x-development-dev'
OPENY_VERSION='8.x-2.x'
GIT_REMOTE_ORIGIN='git@github.com:USER/openy.git'
```
- [ ]  Replace `USER` by your user name from github (You should have `ymcatwincities/openy` fork)
Also you can set here corresponding versions of openy-project and openy.
- [ ]  Run `fin build_project` command inside your project directory.
As result you will get full Open Y installation in your file system.
- [ ]   Last step - run `fin init` command inside your project directory.
As result you will get installed site.
- [ ]  go to profile directory
- [ ]  run `git remote -v`
- [ ] check that you can see here your remote and `ymcatwincities/openy`
- [ ]  run `git status`
- [ ]  check that branch name is '8.x-2.x' or your `OPENY_VERSION`