### PR TITLE
Rewrite build_project command to use a locally checkout openy

### DIFF
--- a/.docksal/commands/build_project
+++ b/.docksal/commands/build_project
@@ -19,27 +19,11 @@ PROJECT_NAME="openy_project"
 IGNORE_REQUIRED="^.$ ^..$ .docksal"
 COMPOSER_PROJECT="${PROJECT_ROOT}/${PROJECT_NAME}"
 DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT:-docroot}"
-OPENY_PATH="${DOCROOT_PATH}/profiles/contrib/openy"
+OPENY_PATH="${DOCROOT:-docroot}/profiles/contrib/openy"
 
 #-------------------------- END: Settings --------------------------------
 
 #-------------------------- Functions --------------------------------
-
-# Setup composer project.
-setup_project ()
-{
-  cd "$PROJECT_ROOT"
-  fin composer create-project "ymcatwincities/openy-project:$OPENY_PROJECT_VERSION" "$PROJECT_NAME" --no-interaction --no-dev
-  cd "$COMPOSER_PROJECT" && fin composer update
-
-  # Remove downloaded docksal directory.
-  rm -rf "${COMPOSER_PROJECT}/.docksal"
-  # Move all files from COMPOSER_PROJECT to root directory.
-  cd "$COMPOSER_PROJECT"
-  mv * .[^.]* ..
-  # Remove empty directory.
-  rm -rf "$COMPOSER_PROJECT"
-}
 
 # Cleanup project.
 cleanup ()
@@ -68,20 +52,42 @@ cleanup ()
   fin exec "$RM_CMD"
 }
 
+# Checkout composer project.
+checkout_composer_project ()
+{
+  cd "$PROJECT_ROOT"
+  fin exec "git clone git@github.com:ymcatwincities/openy-project.git $PROJECT_NAME"
+  cd "$COMPOSER_PROJECT"
+  fin exec git checkout $OPENY_PROJECT_VERSION
+  rm -rf ".git"
+}
+
 # Init GIT repository in project.
 init_git_repo ()
 {
-  cd "$OPENY_PATH"
-  fin exec "rm -rf .git"
-  fin exec "git init"
-  fin exec "git add --all" >/dev/null
-  fin exec 'git commit -m "Initial commit"' >/dev/null
-  fin exec "git remote add origin $GIT_REMOTE_ORIGIN"
+  cd "$COMPOSER_PROJECT"
+  mkdir -p "$OPENY_PATH" && cd "$OPENY_PATH"
+  fin exec "git clone $GIT_REMOTE_ORIGIN ."
   if [ -n "$GIT_REMOTE_UPSTREAM" ]; then
     fin exec "git remote add upstream $GIT_REMOTE_UPSTREAM"
   fi
-  fin exec "git fetch origin"
   fin exec "git checkout $OPENY_VERSION"
+}
+
+# Install composer project.
+install_project ()
+{
+  cd "$COMPOSER_PROJECT"
+  fin exec "composer config repositories.openy_dev path $OPENY_PATH"
+  fin composer update
+
+  # Remove downloaded docksal directory.
+  rm -rf ".docksal"
+
+  # Move all files from COMPOSER_PROJECT to root directory.
+  mv * .[^.]* ..
+  # Remove empty directory.
+  rm -rf "$COMPOSER_PROJECT"
 }
 
 #-------------------------- END: Functions ---------------------------
@@ -98,11 +104,14 @@ fi
 echo-green-bg " Step 2: Cleanup."
 time cleanup
 
-echo-green-bg " Step 3: Build project."
-time setup_project
+echo-green-bg " Step 3: Checkout composer project."
+time checkout_composer_project
 
-echo-green-bg " Step 4: Init git repo and add remote."
+echo-green-bg " Step 4: Init git repo and add upstream remote."
 time init_git_repo
+
+echo-green-bg " Step 5: Install project using composer and attach openy."
+time install_project
 
 echo -en "${green_bg} DONE! ${NC} "
 echo "Run 'fin init' to install Open Y."

--- a/README.md
+++ b/README.md
@@ -26,17 +26,31 @@ git clone git@github.com:ymcatwincities/openy-docksal.git
 
 - Create `docksal-local.env` file inside `.docksal` directory with content:
 ```yaml
-OPENY_PROJECT_VERSION='8.2.x-dev'
+OPENY_PROJECT_VERSION='8.2.x'
 OPENY_VERSION='8.x-2.x'
 GIT_REMOTE_UPSTREAM='git@github.com:USER/openy.git'
 IGNORE_CUSTOM='.idea'
 ```
-- Replace `USER` by your user name from github or remove `GIT_REMOTE_UPSTREAM` if you doesn't have fork of `ymcatwincities/openy`
-Also you can set here corresponding versions of openy-project and openy.
+- Use `OPENY_PROJECT_VERSION` to specify the branch of the 
+`ymcatwincities/openy-project` to be used as a composer project. In the most 
+cases you'll need:
 
-- During execution of `build_project` command all directories except ignored will be deleted. 
-If you work on already existing project and want to save any folder in project root directory - add folder name
-to `IGNORE_CUSTOM`. Directories names should be separated by spaces.
+  - `8.2.x` for a last stable openy release.
+  - `8.2.x-development` for a latest development openy.
+  
+- Use `OPENY_VERSION` to specify the branch of the `ymcatwincities/openy` will 
+be checkout automatically. Take in mind, the openy version corresponds the one, 
+required in a root `composer.json`. Use `8.x-2.x` to start the development from 
+the latest openy progress.
+
+- Replace `USER` by your user name from github or remove `GIT_REMOTE_UPSTREAM` 
+if you don't need an upstream repository to be set automatically.
+
+- During an execution of a `build_project` command, all the directories except 
+an ignored ones would be deleted. 
+If you work on the existing project and want to save any folder in a project 
+root directory - add folder name to `IGNORE_CUSTOM`. Directories names should be 
+separated with spaces.
 
 If you want to use your fork as an origin remote and the main repository as an 
 upstream remote, add the following variables to the `docksal-local.env` file 
@@ -53,21 +67,22 @@ Run this command inside your project directory:
 ```bash
 fin build_project
 ```
-As result you will get full Open Y installation in your file system.
+As a result you will get full Open Y installation in your file system.
 
-The "Killed" message during command run usually means that you need to increase memory limits in your Docksal.
-For macOS or Windows overall memory volume available for Docker is limited by the virtual machine or Docker Desktop 
+The "Killed" message during command run usually means that you need to increase 
+memory limits in your Docksal. For macOS or Windows overall memory volume 
+available for Docker is limited by the virtual machine or Docker Desktop 
 settings.
 
 #### Install Open Y site
 
-After `fin build_project` command finish you need to install site. For this 
+After `fin build_project` command finish you need to install a site. For this 
 you can use one of this commands:
 - `fin init`
 - `fin install_steps`
 - `fin upgrade_init`
 
-More details about this commands you can get below.
+More details about these commands you can get below.
 
 ## Alternative installation process
 


### PR DESCRIPTION
Improve the build_project command -- to firstly check out the openy locally, and then use it as a package for the project.

Steps for review:
- [ ] Clone openy-docksal and add these changes (apply the patch, etc)
- [ ] Create `docksal-local.env` file inside `.docksal` directory with content:
```
OPENY_PROJECT_VERSION='8.2.x-development'
OPENY_VERSION='8.x-2.x'
GIT_REMOTE_UPSTREAM='git@github.com:USER/openy.git'
```
- [ ] Replace `USER` with your GitHub user name (or any other, having `ymcatwincities/openy` fork)
Also, you can set here the needed branches of `openy-project` and `openy` repositories to be checkout and used for building a resulting project.
- [ ] Run `fin build_project` command inside your project directory. Ensure it was executed with a success.
- [ ] Run `fin exec composer config repositories.openy_dev` and ensure it has a path to the local openy installation.
- [ ] Ensure the content of the `composer.json` corresponds to the one in the `ymcatwincities/openy-project`, for the branch you've specified in the `OPENY_PROJECT_VERSION`, except the repositories keys and newly added repository `openy_dev`.
- [ ] Go inside the `docroot/profiles/contrib/openy`.
- [ ] Run `git remote -v`
- [ ] Ensure that there are present remotes: `git@github.com:ymcatwincities/openy.git` if you've not set other value using `GIT_REMOTE_ORIGIN`, and the one you've specified in the `GIT_REMOTE_UPSTREAM`.
- [ ] Run `git status` command and ensure you're on the branch specified in the `OPENY_VERSION`.
- [ ] Run `fin init` command inside your project directory. Ensure it gives you an installed site.