### PR TITLE
Remove query_cache_size

### DIFF
--- a/.docksal/etc/mysql/my.cnf
+++ b/.docksal/etc/mysql/my.cnf
@@ -8,7 +8,6 @@ read_buffer_size = 2M
 read_rnd_buffer_size = 8M
 myisam_sort_buffer_size = 64M
 thread_cache_size = 8
-query_cache_size = 16M
 max_connections = 151
 # Other settings.
 wait_timeout = 500


### PR DESCRIPTION
Deprecated in mysql 5.7 and removed in 8: 

https://dev.mysql.com/doc/refman/5.7/en/query-cache-configuration.html
https://dev.mysql.com/doc/refman/8.0/en/added-deprecated-removed.html#:~:text=in%20MySQL%208.0.3.-,query_cache_size,-%3A%20Memory%20allocated%20to